### PR TITLE
Fix Semaphore deadlock issue

### DIFF
--- a/limiters/semaphore.py
+++ b/limiters/semaphore.py
@@ -17,7 +17,7 @@ class SemaphoreBase(BaseModel):
     name: str
     capacity: int = Field(gt=0)
     max_sleep: float = Field(ge=0, default=0.0)
-    expiry: int | None = None
+    expiry: int = 30
 
     @property
     def key(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-rate-limiters"
-version = "0.2.0"
+version = "0.3.0"
 description = "Distributed rate limiters"
 license = "BSD-4-Clause"
 authors = ["Sondre Lillebø Gundersen <sondrelg@live.no>"]


### PR DESCRIPTION
## Motivation
The old implementation would run `EXPIRE` calls when the context manager exits as a way to handle deadlocks. This unfortunately is not enough, as deadlock will occur when processes gets killed while holding the Semaphore, and to hold the Semaphore you first need to have acquired it with `BLPOP`. `EXPIRE` calls are cancelled when a field is interacted with, so the ordering here means that deadlocks still will occur. 

## Solution
Here, we add additional `EXPIRE` calls to run directly after we acquire the semaphore. That means we should reset the semaphore after `self.expiry` seconds on deadlocks. 

## Notes
The implementation can still lose capacity when processes are killed. We will only hit the expiry when capacity is fully lost. Any ideas for how to get around this are welcome 👍 Maybe we can do a bit of book-keeping and implement an expiry per held lock?