### PR TITLE
Include name in log and error messages

### DIFF
--- a/limiters/token_bucket.py
+++ b/limiters/token_bucket.py
@@ -38,10 +38,10 @@ class TokenBucketBase(BaseModel):
         if self.max_sleep != 0.0 and sleep_time > self.max_sleep:
             raise MaxSleepExceededError(
                 f'Scheduled to sleep `{sleep_time}` seconds. '
-                f'This exceeds the maximum accepted sleep time of `{self.max_sleep}` seconds.'
+                f'This exceeds the maximum accepted sleep time of `{self.max_sleep}` seconds for {self.name}.'
             )
 
-        logger.info('Sleeping %s seconds', sleep_time)
+        logger.info('Sleeping %s seconds (%s)', sleep_time, self.name)
         return sleep_time
 
     @property


### PR DESCRIPTION
## What
Include the name, which is used to create the redis key, when outputting log and error messages.

## Why
Makes it easier to find messages originating from a specific token bucket, in repositories that are using multiple buckets. 