### PR TITLE
Return sleep time in SyncTokenBucket enter, for usage outside package

### DIFF
--- a/limiters/token_bucket.py
+++ b/limiters/token_bucket.py
@@ -55,7 +55,7 @@ class TokenBucketBase(BaseModel):
 class SyncTokenBucket(TokenBucketBase, SyncLuaScriptBase):
     script_name: ClassVar[str] = 'token_bucket.lua'
 
-    def __enter__(self) -> None:
+    def __enter__(self) -> float:
         """
         Call the token bucket Lua script, receive a datetime for
         when to wake up, then sleep up until that point in time.
@@ -71,6 +71,8 @@ class SyncTokenBucket(TokenBucketBase, SyncLuaScriptBase):
 
         # Sleep before returning
         time.sleep(sleep_time)
+
+        return sleep_time
 
     def __exit__(
         self,

--- a/tests/semaphore/test_async_semaphore.py
+++ b/tests/semaphore/test_async_semaphore.py
@@ -106,12 +106,10 @@ def test_init_types(config, error, connection):
 async def test_max_sleep(connection):
     name = uuid4().hex[:6]
     with pytest.raises(MaxSleepExceededError, match=r'Max sleep \(1\.0s\) exceeded waiting for Semaphore'):
-        await asyncio.gather(
-            *[
-                asyncio.create_task(run(async_semaphore_factory(connection=connection(), name=name, max_sleep=1), 1))
-                for _ in range(3)
-            ]
-        )
+        await asyncio.gather(*[
+            asyncio.create_task(run(async_semaphore_factory(connection=connection(), name=name, max_sleep=1), 1))
+            for _ in range(3)
+        ])
 
 
 @pytest.mark.parametrize('connection', [STANDALONE_ASYNC_CONNECTION])

--- a/tests/token_bucket/test_async_token_bucket.py
+++ b/tests/token_bucket/test_async_token_bucket.py
@@ -126,9 +126,7 @@ async def test_max_sleep(connection):
         r' seconds.'
     )
     with pytest.raises(MaxSleepExceededError, match=e):
-        await asyncio.gather(
-            *[
-                asyncio.create_task(run(async_tokenbucket_factory(connection=connection, name=name, max_sleep=1), 0))
-                for _ in range(10)
-            ]
-        )
+        await asyncio.gather(*[
+            asyncio.create_task(run(async_tokenbucket_factory(connection=connection, name=name, max_sleep=1), 0))
+            for _ in range(10)
+        ])


### PR DESCRIPTION
We add this so that anyone that uses this bucket can easily use the sleep time to something useful outside.

For the first case, we want to allow this to be logged to prometheus to monitor sleep time and alert easily when the threshold is about to be met